### PR TITLE
Revert "allow local build" because it apparently breaks https

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build
-        run: yarn && PUBLIC_URL="http://hurricane996.github.io/speedrun-pb-graph" yarn build
+        run: yarn && yarn build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "speedrun-pb-graph",
   "version": "0.1.0",
+  "homepage": "http://hurricane996.github.io/speedrun-pb-graph",
   "private": true,
   "dependencies": {
     "chart.js": "^3.4.1",


### PR DESCRIPTION
Reverts Hurricane996/speedrun-pb-graph#56